### PR TITLE
Feature/improve option decodable conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: xcrun llvm-cov export -format="lcov" .build/debug/swift-argument-encodingPackageTests.xctest/Contents/MacOS/swift-argument-encodingPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage_report.lcov
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
   linux-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Pods/
 .DS_Store
 .AppleDouble
 .LSOverride
+/.default.profraw
 
 # Icon must end with two \r
 Icon

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "0625932976b3ae23949f6b816d13bd97f3b40b7c",
+        "version" : "0.10.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "f9acfa1a45f4483fe0f2c434a74e6f68f865d12d",
+        "version" : "0.3.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",
       "state" : {
-        "revision" : "98650d886ec950b587d671261f06d6b59dec4052",
-        "version" : "0.4.1"
+        "revision" : "ad0a6a0dd4d4741263e798f4f5029589c9b5da73",
+        "version" : "0.4.2"
       }
     },
     {

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -4,6 +4,7 @@
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
 
 import Dependencies
+import Foundation
 
 /// A key/value pair argument that provides a given value for a option or variable.
 ///
@@ -303,6 +304,13 @@ extension Option: ExpressibleByStringLiteral where Value: StringProtocol {
 extension Option: ExpressibleByStringInterpolation where Value: StringProtocol {
     public init(stringInterpolation: DefaultStringInterpolation) {
         self.init(wrappedValue: Value(stringInterpolation: stringInterpolation))
+    }
+}
+
+extension Option: DecodableWithConfiguration where Value: Decodable {
+    public init(from decoder: Decoder, configuration: @escaping @Sendable (Value) -> [String]) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(wrappedValue: container.decode(Value.self), nil, configuration)
     }
 }
 

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -112,7 +112,7 @@ extension Option where Value: CustomStringConvertible {
     public init(key: some CustomStringConvertible, value: Value) {
         keyOverride = key.description
         wrappedValue = value
-        unwrap = { [$0.description] }
+        unwrap = Self.unwrap(_:)
     }
 
     /// Initializes a new option when used as a `@propertyWrapper`
@@ -123,7 +123,12 @@ extension Option where Value: CustomStringConvertible {
     public init(wrappedValue: Value, _ key: String? = nil) {
         keyOverride = key
         self.wrappedValue = wrappedValue
-        unwrap = { [$0.description] }
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap(_ value: Value) -> [String] {
+        [value.description]
     }
 }
 
@@ -140,7 +145,7 @@ extension Option {
     {
         keyOverride = key.description
         wrappedValue = value
-        unwrap = { [$0?.description].compactMap { $0 } }
+        unwrap = Self.unwrap(_:)
     }
 
     /// Initializes a new option when used as a `@propertyWrapper`
@@ -153,7 +158,14 @@ extension Option {
     {
         keyOverride = key
         self.wrappedValue = wrappedValue
-        unwrap = { [$0?.description].compactMap { $0 } }
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap<Wrapped>(_ value: Wrapped?) -> [String] where Wrapped: CustomStringConvertible,
+        Value == Wrapped?
+    {
+        [value?.description].compactMap { $0 }
     }
 }
 
@@ -170,7 +182,7 @@ extension Option {
     {
         keyOverride = key.description
         wrappedValue = values
-        unwrap = { $0.map(\E.description) }
+        unwrap = Self.unwrap(_:)
     }
 
     /// Initializes a new option when used as a `@propertyWrapper`
@@ -183,7 +195,14 @@ extension Option {
     {
         keyOverride = key
         self.wrappedValue = wrappedValue
-        unwrap = { $0.map(\E.description) }
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap<E>(_ value: Value) -> [String] where Value: Sequence, Value.Element == E,
+        E: CustomStringConvertible
+    {
+        value.map(\E.description)
     }
 }
 

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -132,6 +132,66 @@ extension Option where Value: CustomStringConvertible {
     }
 }
 
+extension Option where Value: RawRepresentable, Value.RawValue: CustomStringConvertible {
+    /// Initializes a new option when not used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - key: Explicit key value
+    ///     - wrappedValue: The underlying value
+    public init(key: some CustomStringConvertible, value: Value) {
+        keyOverride = key.description
+        wrappedValue = value
+        unwrap = Self.unwrap(_:)
+    }
+
+    /// Initializes a new option when used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - wrappedValue: The underlying value
+    ///     - _ key: Optional explicit key value
+    public init(wrappedValue: Value, _ key: String? = nil) {
+        keyOverride = key
+        self.wrappedValue = wrappedValue
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap(_ value: Value) -> [String] {
+        [value.rawValue.description]
+    }
+}
+
+extension Option where Value: CustomStringConvertible, Value: RawRepresentable,
+    Value.RawValue: CustomStringConvertible
+{
+    /// Initializes a new option when not used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - key: Explicit key value
+    ///     - wrappedValue: The underlying value
+    public init(key: some CustomStringConvertible, value: Value) {
+        keyOverride = key.description
+        wrappedValue = value
+        unwrap = Self.unwrap(_:)
+    }
+
+    /// Initializes a new option when used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - wrappedValue: The underlying value
+    ///     - _ key: Optional explicit key value
+    public init(wrappedValue: Value, _ key: String? = nil) {
+        keyOverride = key
+        self.wrappedValue = wrappedValue
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap(_ value: Value) -> [String] {
+        [value.rawValue.description]
+    }
+}
+
 // MARK: Convenience initializers when Value == Optional<Wrapped>
 
 extension Option {

--- a/Tests/ArgumentEncodingTests/OptionTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionTests.swift
@@ -17,4 +17,40 @@ final class OptionTests: XCTestCase {
         }
         XCTAssertEqual(args, ["--configuration", "release"])
     }
+
+    func testBothRawValueAndStringConvertible() throws {
+        let option = Option(key: "configuration", value: RawValueCustomStringConvertible(rawValue: "release"))
+        let args = withDependencies { values in
+            values.optionFormatter = .doubleDashPrefix
+        } operation: {
+            option.arguments()
+        }
+        XCTAssertEqual(args, ["--configuration", "release"])
+    }
+
+    func testBothRawValueAndStringConvertibleContainer() throws {
+        let container = Container(configuration: RawValueCustomStringConvertible(rawValue: "release"))
+        let args = withDependencies { values in
+            values.optionFormatter = .doubleDashPrefix
+        } operation: {
+            container.arguments()
+        }
+        XCTAssertEqual(args, ["--configuration", "release"])
+    }
+}
+
+private struct RawValueCustomStringConvertible: RawRepresentable, CustomStringConvertible {
+    var rawValue: String
+
+    var description: String {
+        "description=" + rawValue
+    }
+}
+
+private struct Container: ArgumentGroup {
+    @Option var configuration: RawValueCustomStringConvertible
+
+    init(configuration: RawValueCustomStringConvertible) {
+        _configuration = Option(wrappedValue: configuration)
+    }
 }


### PR DESCRIPTION
- Add static functions of unwrap implementations on Option when unwrap is not required in the initializer
- Add convenience initializers when Value conforms to RawRepresentable<CustomStringConvertible> and when Value conforms to both RawRepresentable<CustomStringConvertible> and CustomStringConvertible
- Relax Option's conformance to Decodable to not require Value conform to CustomStringConvertible. Instead, throw error if unwrap implementation is not found in the Decoder's userInfo dictionary
- Add conditional conformance to DecodableWithConfiguration to Option
- Add test cases to OptionTests to catch regressions of behavior when Option.Value conforms to both RawRepresentable<CustomStringConvertible> and CustomStringConvertible
- Add default.profraw to gitignore
- Add explicit token for codecov in macos-test workflow job
- Update dependencies