### PR TITLE
Fix missing license disclaimer in file headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,12 @@ jobs:
     environment: default
     steps:
       - uses: actions/checkout@v3
+      - name: SwiftFormat version
+        run: swiftformat --version
       - name: Format lint
         run: swiftformat --lint .
+      - name: SwiftLint version
+        run: swiftlint --version
       - name: Lint
         run: swiftlint lint --quiet
   macos-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Format lint
         run: swiftformat --lint .
       - name: Lint
-        run: swiftlint .
+        run: swiftlint lint --quiet
   macos-test:
     runs-on: macos-13
     environment: default

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,7 @@
 --redundanttype explicit
 --swiftversion 5.7
 --maxwidth 120
---header "{file}\nArgumentEncoding\n\nCopyright © {year} MFB Technologies, Inc. All rights reserved."
+--header "{file}\nArgumentEncoding\n\nCopyright © {year} MFB Technologies, Inc. All rights reserved.\n\nThis source code is licensed under the MIT license found in the\nLICENSE file in the root directory of this source tree."
 --allman false
 --exclude **/output/**/*,.tuist-bin,**/.swiftpm/*,**/.build/*
 --wraparguments before-first

--- a/Examples/Sources/SwiftCommand/RunCommand.swift
+++ b/Examples/Sources/SwiftCommand/RunCommand.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 

--- a/Examples/Sources/SwiftCommand/SwiftCommand.swift
+++ b/Examples/Sources/SwiftCommand/SwiftCommand.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 

--- a/Examples/Sources/SwiftCommand/TestCommand.swift
+++ b/Examples/Sources/SwiftCommand/TestCommand.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 

--- a/Examples/Sources/SwiftCommand/main.swift
+++ b/Examples/Sources/SwiftCommand/main.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 let test = SwiftCommand.test(TestCommand(
     parallel: true,

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "302891700c7fa3b92ebde9fe7b42933f8349f3c7",
-        "version" : "1.0.0"
+        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Sources/ArgumentEncoding/ArgumentGroup.swift
+++ b/Sources/ArgumentEncoding/ArgumentGroup.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 

--- a/Sources/ArgumentEncoding/CaseConverter.swift
+++ b/Sources/ArgumentEncoding/CaseConverter.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 

--- a/Sources/ArgumentEncoding/Command.swift
+++ b/Sources/ArgumentEncoding/Command.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// A command type argument with no nested or children arguments.
 public struct Command: Hashable, Sendable, RawRepresentable {

--- a/Sources/ArgumentEncoding/CommandRepresentable.swift
+++ b/Sources/ArgumentEncoding/CommandRepresentable.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 

--- a/Sources/ArgumentEncoding/DecoderUserInfo+OptionHelpers.swift
+++ b/Sources/ArgumentEncoding/DecoderUserInfo+OptionHelpers.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 

--- a/Sources/ArgumentEncoding/DecoderUserInfo+OptionSetHelpers.swift
+++ b/Sources/ArgumentEncoding/DecoderUserInfo+OptionSetHelpers.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 

--- a/Sources/ArgumentEncoding/Flag.swift
+++ b/Sources/ArgumentEncoding/Flag.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 

--- a/Sources/ArgumentEncoding/FormatterNode.swift
+++ b/Sources/ArgumentEncoding/FormatterNode.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// A protocol that describes a type that defines how flags and options are formatted. Typically, `ArgumentGroup`
 /// conforming types would be formatter nodes so that all their children will inherit the specified formatters.

--- a/Sources/ArgumentEncoding/Formatters.swift
+++ b/Sources/ArgumentEncoding/Formatters.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 import XCTestDynamicOverlay

--- a/Sources/ArgumentEncoding/Formatters.swift
+++ b/Sources/ArgumentEncoding/Formatters.swift
@@ -21,7 +21,7 @@ public struct FlagFormatter: Sendable {
     }
 
     @Sendable
-    internal func _format(encoding: FlagEncoding) -> String {
+    func _format(encoding: FlagEncoding) -> String {
         format(key: encoding.key)
     }
 
@@ -61,7 +61,7 @@ public struct OptionFormatter: Sendable {
         prefix() + body(key) + separator() + value
     }
 
-    internal func format(encoding: OptionEncoding) -> String {
+    func format(encoding: OptionEncoding) -> String {
         format(key: encoding.key, value: encoding.value)
     }
 

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 import Foundation

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -41,7 +41,7 @@ public struct Option<Value>: OptionProtocol {
     // Different Value types will encode to arguments differently.
     // Using unwrap, this can be handled individually per type or collectively by protocol
     private let unwrap: @Sendable (Value) -> String?
-    internal var unwrapped: String? {
+    var unwrapped: String? {
         unwrap(wrappedValue)
     }
 

--- a/Sources/ArgumentEncoding/OptionSet.swift
+++ b/Sources/ArgumentEncoding/OptionSet.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Dependencies
 import Foundation

--- a/Sources/ArgumentEncoding/OptionSet.swift
+++ b/Sources/ArgumentEncoding/OptionSet.swift
@@ -43,7 +43,7 @@ public struct OptionSet<Value>: OptionSetProtocol where Value: Sequence {
     // Different Value types will encode to arguments differently.
     // Using unwrap, this can be handled individually per type or collectively by protocol
     private let unwrap: @Sendable (Value.Element) -> String?
-    internal var unwrapped: [String] {
+    var unwrapped: [String] {
         wrappedValue.compactMap(unwrap)
     }
 

--- a/Sources/ArgumentEncoding/PositionalArgument.swift
+++ b/Sources/ArgumentEncoding/PositionalArgument.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import Foundation
 

--- a/Sources/ArgumentEncoding/PositionalArgument.swift
+++ b/Sources/ArgumentEncoding/PositionalArgument.swift
@@ -29,7 +29,7 @@ public struct Positional<Value>: PositionalProtocol {
     // Different Value types will encode to arguments differently.
     // Using unwrap, this can be handled individually per type or collectively by protocol
     private let unwrap: @Sendable (Value) -> [String]
-    internal var unwrapped: [String] {
+    var unwrapped: [String] {
         unwrap(wrappedValue)
     }
 

--- a/Sources/ArgumentEncoding/StaticString+Constants.swift
+++ b/Sources/ArgumentEncoding/StaticString+Constants.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 extension StaticString {
     public static let space: Self = #" "#

--- a/Sources/ArgumentEncoding/TopLevelCommandRepresentable.swift
+++ b/Sources/ArgumentEncoding/TopLevelCommandRepresentable.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// A type that represents a command type argument that is not a child of an `ArgumentGroup`.
 ///

--- a/Tests/ArgumentEncodingTests/ArgumentGroupTests.swift
+++ b/Tests/ArgumentEncodingTests/ArgumentGroupTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Dependencies

--- a/Tests/ArgumentEncodingTests/CommandRepresentableTests.swift
+++ b/Tests/ArgumentEncodingTests/CommandRepresentableTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import XCTest

--- a/Tests/ArgumentEncodingTests/CommandTests.swift
+++ b/Tests/ArgumentEncodingTests/CommandTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import XCTest

--- a/Tests/ArgumentEncodingTests/FlagTests.swift
+++ b/Tests/ArgumentEncodingTests/FlagTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Dependencies

--- a/Tests/ArgumentEncodingTests/FormatterTests.swift
+++ b/Tests/ArgumentEncodingTests/FormatterTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Foundation

--- a/Tests/ArgumentEncodingTests/OptionDecodingTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionDecodingTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Foundation

--- a/Tests/ArgumentEncodingTests/OptionSetDecodingTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionSetDecodingTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Foundation

--- a/Tests/ArgumentEncodingTests/OptionSetTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionSetTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Dependencies

--- a/Tests/ArgumentEncodingTests/OptionTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Dependencies

--- a/Tests/ArgumentEncodingTests/PositionalTests.swift
+++ b/Tests/ArgumentEncodingTests/PositionalTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import Dependencies

--- a/Tests/ArgumentEncodingTests/TopLevelCommandRepresentableTests.swift
+++ b/Tests/ArgumentEncodingTests/TopLevelCommandRepresentableTests.swift
@@ -2,6 +2,9 @@
 // ArgumentEncoding
 //
 // Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 import ArgumentEncoding
 import XCTest


### PR DESCRIPTION
Add the missing license disclaimer to the auto-generated file headers.