### PR TITLE
Strict concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     environment: default
     strategy:
       matrix:
-        xcode: ['14.2', '14.3']
-        # Swift: 5.7  , 5.8
+        xcode: ['14.3', '15.0']
+        # Swift: 5.8  , 5.9
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 --extensionacl on-declarations
 --redundanttype explicit
---swiftversion 5.7
+--swiftversion 5.8
 --maxwidth 120
 --header "{file}\nArgumentEncoding\n\nCopyright © {year} MFB Technologies, Inc. All rights reserved.\n\nThis source code is licensed under the MIT license found in the\nLICENSE file in the root directory of this source tree."
 --allman false

--- a/Examples/Sources/SwiftCommand/RunCommand.swift
+++ b/Examples/Sources/SwiftCommand/RunCommand.swift
@@ -1,7 +1,7 @@
 // RunCommand.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Examples/Sources/SwiftCommand/SwiftCommand.swift
+++ b/Examples/Sources/SwiftCommand/SwiftCommand.swift
@@ -1,7 +1,7 @@
 // SwiftCommand.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Examples/Sources/SwiftCommand/TestCommand.swift
+++ b/Examples/Sources/SwiftCommand/TestCommand.swift
@@ -1,7 +1,7 @@
 // TestCommand.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Examples/Sources/SwiftCommand/main.swift
+++ b/Examples/Sources/SwiftCommand/main.swift
@@ -1,7 +1,7 @@
 // main.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
 
 package.targets.strictConcurrency()
 
-extension Array where Element == Target {
+extension [Target] {
     func strictConcurrency() {
         forEach { target in
             target.swiftSettings = (target.swiftSettings ?? [])

--- a/Package.swift
+++ b/Package.swift
@@ -16,27 +16,18 @@ let package = Package(
             name: "ArgumentEncoding",
             dependencies: [
                 .dependencies,
-            ]
+            ],
+            swiftSettings: .swiftSix
         ),
         .testTarget(
             name: "ArgumentEncodingTests",
             dependencies: [
                 "ArgumentEncoding",
-            ]
+            ],
+            swiftSettings: .swiftSix
         ),
     ]
 )
-
-package.targets.strictConcurrency()
-
-extension [Target] {
-    func strictConcurrency() {
-        forEach { target in
-            target.swiftSettings = (target.swiftSettings ?? [])
-                + [.enableUpcomingFeature("StrictConcurrency")]
-        }
-    }
-}
 
 // MARK: PointFree
 
@@ -49,4 +40,17 @@ extension Package.Dependency {
 
 extension Target.Dependency {
     static let dependencies: Self = .product(name: "Dependencies", package: "swift-dependencies")
+}
+
+extension [SwiftSetting] {
+    static let swiftSix: Self = [
+        .enableUpcomingFeature("BareSlashRegexLiterals"),
+        .enableUpcomingFeature("ConciseMagicFile"),
+        .enableUpcomingFeature("DeprecateApplicationMain"),
+        .enableUpcomingFeature("DisableOutwardActorInference"),
+        .enableUpcomingFeature("ForwardTrailingClosures"),
+        .enableUpcomingFeature("ImportObjcForwardDeclarations"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("StrictConcurrency"),
+    ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,17 @@ let package = Package(
     ]
 )
 
+package.targets.strictConcurrency()
+
+extension Array where Element == Target {
+    func strictConcurrency() {
+        forEach { target in
+            target.swiftSettings = (target.swiftSettings ?? [])
+                + [.enableUpcomingFeature("StrictConcurrency")]
+        }
+    }
+}
+
 // MARK: PointFree
 
 extension Package.Dependency {

--- a/Sources/ArgumentEncoding/ArgumentGroup.swift
+++ b/Sources/ArgumentEncoding/ArgumentGroup.swift
@@ -1,7 +1,7 @@
 // ArgumentGroup.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/CaseConverter.swift
+++ b/Sources/ArgumentEncoding/CaseConverter.swift
@@ -1,7 +1,7 @@
 // CaseConverter.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/Command.swift
+++ b/Sources/ArgumentEncoding/Command.swift
@@ -1,7 +1,7 @@
 // Command.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/CommandRepresentable.swift
+++ b/Sources/ArgumentEncoding/CommandRepresentable.swift
@@ -1,7 +1,7 @@
 // CommandRepresentable.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/DecoderUserInfo+OptionHelpers.swift
+++ b/Sources/ArgumentEncoding/DecoderUserInfo+OptionHelpers.swift
@@ -1,7 +1,7 @@
 // DecoderUserInfo+OptionHelpers.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/DecoderUserInfo+OptionSetHelpers.swift
+++ b/Sources/ArgumentEncoding/DecoderUserInfo+OptionSetHelpers.swift
@@ -1,7 +1,7 @@
 // DecoderUserInfo+OptionSetHelpers.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/Flag.swift
+++ b/Sources/ArgumentEncoding/Flag.swift
@@ -1,7 +1,7 @@
 // Flag.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/FormatterNode.swift
+++ b/Sources/ArgumentEncoding/FormatterNode.swift
@@ -1,7 +1,7 @@
 // FormatterNode.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/Formatters.swift
+++ b/Sources/ArgumentEncoding/Formatters.swift
@@ -1,7 +1,7 @@
 // Formatters.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/Option.swift
+++ b/Sources/ArgumentEncoding/Option.swift
@@ -1,7 +1,7 @@
 // Option.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/OptionSet.swift
+++ b/Sources/ArgumentEncoding/OptionSet.swift
@@ -1,7 +1,7 @@
 // OptionSet.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/PositionalArgument.swift
+++ b/Sources/ArgumentEncoding/PositionalArgument.swift
@@ -1,7 +1,7 @@
 // PositionalArgument.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/StaticString+Constants.swift
+++ b/Sources/ArgumentEncoding/StaticString+Constants.swift
@@ -1,7 +1,7 @@
 // StaticString+Constants.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Sources/ArgumentEncoding/TopLevelCommandRepresentable.swift
+++ b/Sources/ArgumentEncoding/TopLevelCommandRepresentable.swift
@@ -1,7 +1,7 @@
 // TopLevelCommandRepresentable.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/ArgumentGroupTests.swift
+++ b/Tests/ArgumentEncodingTests/ArgumentGroupTests.swift
@@ -1,7 +1,7 @@
 // ArgumentGroupTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/CommandRepresentableTests.swift
+++ b/Tests/ArgumentEncodingTests/CommandRepresentableTests.swift
@@ -1,7 +1,7 @@
 // CommandRepresentableTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/CommandTests.swift
+++ b/Tests/ArgumentEncodingTests/CommandTests.swift
@@ -1,7 +1,7 @@
 // CommandTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/FlagTests.swift
+++ b/Tests/ArgumentEncodingTests/FlagTests.swift
@@ -1,7 +1,7 @@
 // FlagTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/FormatterTests.swift
+++ b/Tests/ArgumentEncodingTests/FormatterTests.swift
@@ -1,7 +1,7 @@
 // FormatterTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/OptionDecodingTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionDecodingTests.swift
@@ -1,7 +1,7 @@
 // OptionDecodingTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/OptionSetDecodingTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionSetDecodingTests.swift
@@ -1,7 +1,7 @@
 // OptionSetDecodingTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/OptionSetTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionSetTests.swift
@@ -1,7 +1,7 @@
 // OptionSetTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/OptionTests.swift
+++ b/Tests/ArgumentEncodingTests/OptionTests.swift
@@ -1,7 +1,7 @@
 // OptionTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/PositionalTests.swift
+++ b/Tests/ArgumentEncodingTests/PositionalTests.swift
@@ -1,7 +1,7 @@
 // PositionalTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.

--- a/Tests/ArgumentEncodingTests/TopLevelCommandRepresentableTests.swift
+++ b/Tests/ArgumentEncodingTests/TopLevelCommandRepresentableTests.swift
@@ -1,7 +1,7 @@
 // TopLevelCommandRepresentableTests.swift
 // ArgumentEncoding
 //
-// Copyright © 2023 MFB Technologies, Inc. All rights reserved.
+// Copyright © 2024 MFB Technologies, Inc. All rights reserved.
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
- Bump minimum swift tools version to 5.8
- Enable strict concurrency checking
- Remove Xcode 14.2/Swift 5.7 and add Xcode 15.0/Swift 5.9 test strategies
- Bump swiftformat Swift version to 5.8
- Simplify Swift settings in manifest and add other Swift 6.0 settings
- Run swiftformat (updated file header dates)