### PR TITLE
Initialize Positional with a type that conforms to ArgumentGroup

### DIFF
--- a/Sources/ArgumentEncoding/PositionalArgument.swift
+++ b/Sources/ArgumentEncoding/PositionalArgument.swift
@@ -224,6 +224,33 @@ extension Positional {
     }
 }
 
+// MARK: Convenience initializers when Value: ArgumentGroup
+
+extension Positional where Value: ArgumentGroup {
+    /// Initializes a new positional when not used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - wrappedValue: The underlying value
+    public init(value: Value) {
+        wrappedValue = value
+        unwrap = Self.unwrap(_:)
+    }
+
+    /// Initializes a new positional when used as a `@propertyWrapper`
+    ///
+    /// - Parameters
+    ///     - wrappedValue: The underlying value
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+        unwrap = Self.unwrap(_:)
+    }
+
+    @Sendable
+    public static func unwrap(_ value: Value) -> [String] {
+        value.arguments()
+    }
+}
+
 // MARK: ExpressibleBy...Literal conformances
 
 extension Positional: ExpressibleByIntegerLiteral where Value: BinaryInteger, Value.IntegerLiteralType == Int {

--- a/Tests/ArgumentEncodingTests/PositionalTests.swift
+++ b/Tests/ArgumentEncodingTests/PositionalTests.swift
@@ -26,6 +26,15 @@ final class PositionalTests: XCTestCase {
         let args = container.arguments()
         XCTAssertEqual(args, ["positional-argument"])
     }
+
+    func testPositionalArgumentGroup() throws {
+        let positional =
+            Positional(
+                value: Container(configuration: RawValueCustomStringConvertible(rawValue: "positional-argument"))
+            )
+        let args = positional.arguments()
+        XCTAssertEqual(args, ["positional-argument"])
+    }
 }
 
 private struct RawValueCustomStringConvertible: RawRepresentable, CustomStringConvertible {


### PR DESCRIPTION
If a `command A` takes `command B` as an argument, this makes it easier to define `command B` as a `Positional` property on `command A`.

For example:
`mise --cd {{ project path }} x tuist -- tuist version`
`mise` is `command A` and `tuist version` is `command B`